### PR TITLE
Library dev

### DIFF
--- a/appContainer/App.jsx
+++ b/appContainer/App.jsx
@@ -1,18 +1,21 @@
 import React, { Component } from "react";
-import { clearMessage } from "../message/messageActions";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
-import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import NavBar from "../navBar/components/NavBar.jsx";
 import Message from "../message/container/Message.jsx";
 
-export class App extends Component {
+class App extends Component {
 
   static get propTypes() {
     return {
       // Config Props, inherited from parent
       viewsConfig: PropTypes.array.isRequired,
       navbarConfig: PropTypes.object.isRequired,
+      customNavUtility: PropTypes.oneOfType([
+        PropTypes.array,
+        PropTypes.element
+      ]),
+      autoNavUtility: PropTypes.element
     }
   }
 
@@ -29,11 +32,22 @@ export class App extends Component {
     )
   }
 
+  _createNavBar(){
+    if(this.props.customNavUtility !== undefined){
+      return <NavBar config={this.props.navbarConfig} customUtility={this.props.customNavUtility}/>
+    }else if(this.props.autoNavUtility !== undefined){
+      return <NavBar config={this.props.navbarConfig} autoUtility={this.props.autoNavUtility}/>
+    }
+    return (
+      <NavBar config={this.props.navbarConfig}/>
+    )
+  }
+
   render() {
     return (
       <Router>
         <div className="app">
-          <NavBar config={this.props.navbarConfig}/>
+          {this._createNavBar()}
           <Message/>
           {this._createSwitches()}
         </div>

--- a/appContainer/App.jsx
+++ b/appContainer/App.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import NavBar from "../navBar/components/NavBar.jsx";
 import Message from "../message/container/Message.jsx";
 
-class App extends Component {
+export class App extends Component {
 
   static get propTypes() {
     return {
@@ -15,7 +15,10 @@ class App extends Component {
         PropTypes.array,
         PropTypes.element
       ]),
-      autoNavUtility: PropTypes.element
+      autoNavUtility: PropTypes.oneOfType([
+        PropTypes.array,
+        PropTypes.element
+      ]),
     }
   }
 

--- a/navBar/components/NavBar.jsx
+++ b/navBar/components/NavBar.jsx
@@ -13,7 +13,10 @@ export class NavBar extends Component {
         PropTypes.array,
         PropTypes.element
       ]),
-      autoUtility: PropTypes.element,
+      autoUtility: PropTypes.oneOfType([
+        PropTypes.array,
+        PropTypes.element
+      ]),
     }
   }
 

--- a/navBar/components/NavBar.jsx
+++ b/navBar/components/NavBar.jsx
@@ -9,6 +9,11 @@ export class NavBar extends Component {
   static get propTypes(){
     return {
       config: PropTypes.object.isRequired,
+      customUtility: PropTypes.oneOfType([
+        PropTypes.array,
+        PropTypes.element
+      ]),
+      autoUtility: PropTypes.element,
     }
   }
 
@@ -35,14 +40,36 @@ export class NavBar extends Component {
       return (i === 0) ? this.createIndexContainer(c ,i) : this.createLinkContainer(c, i);
     });
 
+    // Navbar Utility cases (custom, auto, or none)
+    let utility = null;
+    if(this.props.customUtility !== undefined){
+      utility = this.props.customUtility;
+    }
+    else if(this.props.autoUtility !== undefined){
+      utility =[
+        <button key={0} type="button" className="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
+          <span className="sr-only">Toggle navigation</span>
+          <span className="icon-bar"/>
+          <span className="icon-bar"/>
+          <span className="icon-bar"/>
+        </button>,
+        <div key={1} className="collapse navbar-collapse navbar-collapse-1">
+          <ul className="nav navbar-nav navbar-utility">
+            {this.props.autoUtility}
+          </ul>
+        </div>
+        ]
+    }
+
     return (
-      <Navbar className="navbar navbar-default navbar-pf">
+      <Navbar className="navbar navbar-default navbar-pf" role="navigation">
         <Navbar.Header>
           <Navbar.Toggle/>
           <Link className="navbar-brand" to="/">
             <img src={titleSrc.path} alt={titleSrc.alt}/>
           </Link>
         </Navbar.Header>
+        {utility}
         <Navbar.Collapse>
           <Nav className="navbar-nav navbar-primary" >
             {categoryComponents}


### PR DESCRIPTION
Navbar now allows for users to add Navbar utilities, they can opt to use the autoUtility that only requires basic jsx elements (either a list or a single root element) and the Navbar will automatically display the element on the top right of the screen, it will also be collapsed into a burger icon if the window size is reduced to a threshold. 

Users can also choose to instead use the customUtility, where they can fully customize how the utility should be displayed. 

Both the autoUtility and customUtility are props passed into the Navbar, if both are provided the customUtility is given precedence, if none are provided no utility is shown. 